### PR TITLE
fix: use PAT for bump PRs to trigger CI; fix upstream version comparison

### DIFF
--- a/.github/workflows/check_lego_update.yml
+++ b/.github/workflows/check_lego_update.yml
@@ -55,7 +55,7 @@ jobs:
         if: steps.compare.outputs.up_to_date == 'false'
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CVE_AUTOFIX_TOKEN }}
           branch: "bump/lego-${{ steps.latest.outputs.version }}"
           commit-message: "Bump lego from ${{ steps.pinned.outputs.version }} to ${{ steps.latest.outputs.version }}"
           title: "Bump lego from ${{ steps.pinned.outputs.version }} to ${{ steps.latest.outputs.version }}"

--- a/.github/workflows/check_nginx_update.yml
+++ b/.github/workflows/check_nginx_update.yml
@@ -59,7 +59,7 @@ jobs:
         if: steps.compare.outputs.up_to_date == 'false'
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CVE_AUTOFIX_TOKEN }}
           branch: "bump/nginx-${{ steps.latest.outputs.version }}"
           commit-message: "Bump nginx from ${{ steps.pinned.outputs.version }} to ${{ steps.latest.outputs.version }}"
           title: "Bump nginx from ${{ steps.pinned.outputs.version }} to ${{ steps.latest.outputs.version }}"

--- a/.github/workflows/check_upstream_update.yml
+++ b/.github/workflows/check_upstream_update.yml
@@ -49,12 +49,18 @@ jobs:
         run: |
           SYNCED="${{ steps.synced.outputs.ref }}"
           LATEST="${{ steps.upstream.outputs.tag }}"
-          if [ "$SYNCED" = "$LATEST" ]; then
+          # Strip leading 'v' for semver comparison
+          SYNCED_V=$(echo "$SYNCED" | sed 's/^v//')
+          LATEST_V=$(echo "$LATEST" | sed 's/^v//')
+          # sort -V puts the highest version last; if LATEST_V is not the highest,
+          # we are at the same version or ahead — no action needed
+          HIGHEST=$(printf '%s\n%s' "$SYNCED_V" "$LATEST_V" | sort -V | tail -1)
+          if [ "$HIGHEST" != "$LATEST_V" ] || [ "$SYNCED_V" = "$LATEST_V" ]; then
             echo "up_to_date=true" >> $GITHUB_OUTPUT
-            echo "Already in sync with upstream (${SYNCED})"
+            echo "Up to date or ahead of upstream (ours: ${SYNCED}, upstream: ${LATEST})"
           else
             echo "up_to_date=false" >> $GITHUB_OUTPUT
-            echo "Upstream has moved: ${SYNCED} → ${LATEST}"
+            echo "Upstream is newer: ${SYNCED} → ${LATEST}"
           fi
 
       - name: Check for existing open issue


### PR DESCRIPTION
## Summary

- **PR #36 (no CI checks)**: `check_nginx_update.yml` and `check_lego_update.yml` were using `token: ${{ secrets.GITHUB_TOKEN }}` in `peter-evans/create-pull-request`, which prevents downstream workflow triggers due to GitHub's loop-prevention policy. Changed both to `token: ${{ secrets.CVE_AUTOFIX_TOKEN }}`.

- **Issue #37 (false upstream sync alert)**: `check_upstream_update.yml` used simple string equality to compare the synced ref vs latest upstream release. When our ref (`v6.1.0`) was ahead of upstream (`v6.0.0`), they differed → false issue opened. Fixed with `sort -V` semantic version comparison to detect when we are already at or ahead of upstream.

## Test plan

- [ ] Merge PR and trigger `check_nginx_update` / `check_lego_update` via `workflow_dispatch` — resulting bump PRs should show CI checks running
- [ ] Trigger `check_upstream_update` via `workflow_dispatch` — should report "already in sync" when our `.upstream-sync-ref` is ≥ upstream latest; close issue #37