### PR TITLE
fix: release gate to unblock github_release skip; upgrade node20 actions to node24

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,14 @@ jobs:
     environment: release
     timeout-minutes: 90
     steps:
+      - name: Log dependency results
+        run: |
+          echo "resolve_tag:       ${{ needs.resolve_tag.result }}"
+          echo "integration_check: ${{ needs.integration_check.result }}"
+          echo "scan_debian:       ${{ needs.scan_debian.result }}"
+          echo "scan_alpine:       ${{ needs.scan_alpine.result }}"
+          echo "scan_ubuntu:       ${{ needs.scan_ubuntu.result }}"
+
       - name: Run Docker on tmpfs
         uses: JonasAlfredsson/docker-on-tmpfs@55e939ef196646234a12c245e3414879e3580f01 # v2.0.0
         with:
@@ -352,6 +360,14 @@ jobs:
     environment: release
     timeout-minutes: 45
     steps:
+      - name: Log dependency results
+        run: |
+          echo "resolve_tag:       ${{ needs.resolve_tag.result }}"
+          echo "integration_check: ${{ needs.integration_check.result }}"
+          echo "scan_debian:       ${{ needs.scan_debian.result }}"
+          echo "scan_alpine:       ${{ needs.scan_alpine.result }}"
+          echo "scan_ubuntu:       ${{ needs.scan_ubuntu.result }}"
+
       - name: Run Docker on tmpfs
         uses: JonasAlfredsson/docker-on-tmpfs@55e939ef196646234a12c245e3414879e3580f01 # v2.0.0
         with:
@@ -407,6 +423,14 @@ jobs:
     environment: release
     timeout-minutes: 45
     steps:
+      - name: Log dependency results
+        run: |
+          echo "resolve_tag:       ${{ needs.resolve_tag.result }}"
+          echo "integration_check: ${{ needs.integration_check.result }}"
+          echo "scan_debian:       ${{ needs.scan_debian.result }}"
+          echo "scan_alpine:       ${{ needs.scan_alpine.result }}"
+          echo "scan_ubuntu:       ${{ needs.scan_ubuntu.result }}"
+
       - name: Run Docker on tmpfs
         uses: JonasAlfredsson/docker-on-tmpfs@55e939ef196646234a12c245e3414879e3580f01 # v2.0.0
         with:
@@ -449,8 +473,36 @@ jobs:
           push: true
           tags: ${{ steps.tags.outputs.value }}
 
+  release_gate:
+    name: "Release gate"
+    needs: [resolve_tag, integration_check, scan_debian, scan_alpine, scan_ubuntu, docker_buildx_debian, docker_buildx_alpine, docker_buildx_ubuntu]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log all job results
+        run: |
+          echo "resolve_tag:          ${{ needs.resolve_tag.result }}"
+          echo "integration_check:    ${{ needs.integration_check.result }}"
+          echo "scan_debian:          ${{ needs.scan_debian.result }}"
+          echo "scan_alpine:          ${{ needs.scan_alpine.result }}"
+          echo "scan_ubuntu:          ${{ needs.scan_ubuntu.result }}"
+          echo "docker_buildx_debian: ${{ needs.docker_buildx_debian.result }}"
+          echo "docker_buildx_alpine: ${{ needs.docker_buildx_alpine.result }}"
+          echo "docker_buildx_ubuntu: ${{ needs.docker_buildx_ubuntu.result }}"
+      - name: Check all builds succeeded
+        run: |
+          if [ "${{ needs.resolve_tag.result }}"          != "success" ] || \
+             [ "${{ needs.docker_buildx_debian.result }}" != "success" ] || \
+             [ "${{ needs.docker_buildx_alpine.result }}" != "success" ] || \
+             [ "${{ needs.docker_buildx_ubuntu.result }}" != "success" ]; then
+            echo "Release blocked: one or more required jobs did not succeed"
+            exit 1
+          fi
+          echo "All required builds succeeded — proceeding to GitHub release"
+
   github_release:
-    needs: [resolve_tag, docker_buildx_debian, docker_buildx_alpine, docker_buildx_ubuntu]
+    needs: [resolve_tag, release_gate]
+    if: needs.release_gate.result == 'success'
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -499,7 +551,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -516,6 +568,7 @@ jobs:
   post_release_report:
     name: "Post-release vulnerability report"
     needs: [resolve_tag, github_release]
+    if: always() && needs.github_release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -630,7 +683,7 @@ jobs:
 
   cleanup:
     name: "Revert release on failure or cancellation"
-    needs: [resolve_tag, docker_buildx_debian, docker_buildx_alpine, docker_buildx_ubuntu]
+    needs: [resolve_tag, release_gate, docker_buildx_debian, docker_buildx_alpine, docker_buildx_ubuntu]
     if: failure() || cancelled()
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -235,7 +235,7 @@ jobs:
           token: ${{ secrets.CVE_AUTOFIX_TOKEN }}
 
       - name: Set up QEMU for multi-arch pin verification
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/update_dockerhub_description.yml
+++ b/.github/workflows/update_dockerhub_description.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
## Summary

### Bug fix: `github_release` skipped even when all 3 images built

**Root cause:** GitHub Actions' implicit `success()` condition walks the entire ancestor chain. When scan jobs are skipped (via `skip_security_scan=true`), `success()` returns false for `github_release` even though all three `docker_buildx_*` dependencies succeeded.

**Fix:** Added a `release_gate` job that:
- Runs with `if: always()` — guaranteed to execute regardless of upstream skips/failures
- Logs every dependency result (resolve_tag, integration_check, all scans, all docker_buildx jobs) so the reason for any skip is always visible in the workflow UI
- Fails explicitly if any required build did not succeed
- `github_release` now depends only on `release_gate`, bypassing the ancestor-chain `success()` issue

Also added `Log dependency results` steps to each `docker_buildx_*` job for inline diagnostics, and fixed `post_release_report` with `if: always() && needs.github_release.result == 'success'`.

### Node.js 20 → 24 action upgrades

| Action | Old | New |
|--------|-----|-----|
| `peter-evans/dockerhub-description` | v4.0.0 (node20) | v5.0.0 (node24) |
| `dorny/paths-filter` | v3.0.2 (node20) | v4.0.1 (node24) |
| `docker/setup-qemu-action` | v3.2.0 (node20) | v4.0.0 (node24) |

All other pinned actions (`actions/checkout`, `docker/build-push-action`, `docker/setup-buildx-action`, `peter-evans/create-pull-request`, `actions/upload-artifact`, `actions/download-artifact`) are already on node24. Composite and Docker-runtime actions (`JonasAlfredsson/*`, `ffurrer2/bats-action`, `github/codeql-action`) are unaffected.

## Test plan

- [ ] Trigger release workflow with `skip_security_scan=true` — `release_gate` should succeed and `github_release` should run (not be skipped)
- [ ] Trigger release workflow normally — `release_gate` logs should show all job result values
- [ ] Confirm no Node.js 20 deprecation warnings in any workflow run