### PR TITLE
fix: add always() to github_release to bypass ancestor-chain success() check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -502,7 +502,7 @@ jobs:
 
   github_release:
     needs: [resolve_tag, release_gate]
-    if: needs.release_gate.result == 'success'
+    if: always() && needs.release_gate.result == 'success'
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -568,7 +568,7 @@ jobs:
   post_release_report:
     name: "Post-release vulnerability report"
     needs: [resolve_tag, github_release]
-    if: always() && needs.github_release.result == 'success'
+    if: always() && needs.github_release.result == 'success' && needs.release_gate.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## Root cause

GitHub Actions' `success()` (the implicit default when `if:` has no status function) walks the **full ancestor chain** — not just direct dependencies. Even though `github_release` only directly depends on `resolve_tag` and `release_gate` (both succeeded), `release_gate` itself has skipped ancestors (`scan_*` when `skip_security_scan=true`). GitHub's `success()` sees those skipped ancestors and returns false, causing `github_release` to be skipped.

The previous fix in #39 used `if: needs.release_gate.result == 'success'` — without `always()`, GitHub still applied the implicit `success()` first, which failed on the ancestor chain.

## Fix

Add `always()` to both `github_release` and `post_release_report`. `always()` causes GitHub to skip the implicit ancestor-chain `success()` check and evaluate only the explicit expression.

```yaml
if: always() && needs.release_gate.result == 'success'
```

`release_gate` itself already has `if: always()` and performs the explicit gate check (fails if any build didn't succeed), so this is safe — if the builds failed, `release_gate` fails, and `github_release` is blocked correctly.

## Test plan

- [ ] Trigger release with `skip_security_scan=true` — `github_release` should run (not skip)
- [ ] Trigger release normally — `github_release` should run after scans pass