### PR TITLE
fix: apply severity label to issues created by post_release_report

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -677,7 +677,8 @@ jobs:
               gh issue create --repo "$REPO" \
                 --title "$TITLE" \
                 --body "$BODY" \
-                --label security
+                --label security \
+                --label "severity:$(echo "$SEVERITY" | tr '[:upper:]' '[:lower:]')"
             fi
           done
 


### PR DESCRIPTION
## Summary

`gh issue create` in `post_release_report` was only applying `--label security`. Issues #41–47 were created without a severity-specific label.

Add `--label "severity:$(echo "$SEVERITY" | tr '[:upper:]' '[:lower:]')"` so each new issue gets both `security` and `severity:critical` or `severity:high` automatically.

Issues #41–47 have already been retroactively labeled.

## Test plan

- [ ] Trigger release and verify newly created CVE issues have both `security` and `severity:*` labels