### PR TITLE
fix: pin ubuntu:24.04 base image digest in Dockerfile-ubuntu

### DIFF
--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
 LABEL maintainer="emulatorchen"
 
 # FORK: Uses Ubuntu 24.04 (Noble) as the base instead of the official nginx Docker


### PR DESCRIPTION
## Summary

- Layer 4 (base image digest pinning from PR #49) covered `Dockerfile` and `Dockerfile-alpine` but missed `Dockerfile-ubuntu`
- `Dockerfile-ubuntu` uses `ubuntu:24.04` as its base (installs nginx via apt), not a nginx Docker image
- Pins `FROM ubuntu:24.04` to its manifest list digest

## Notes

- `check_nginx_update.yml` already updates `ARG NGINX_VERSION` in this file on nginx bumps — the ubuntu base digest is unaffected by nginx version changes, so no workflow change needed
- Digest resolved via `docker buildx imagetools inspect ubuntu:24.04 --format '{{json .Manifest}}'`