### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-04-06)

### DIFF
--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -249,6 +249,7 @@ jobs:
       - name: Create auto-fix PR if applicable
         env:
           GH_TOKEN: ${{ secrets.CVE_AUTOFIX_TOKEN }}
+          GH_ISSUE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           # Conditions for auto-fix PR (all must be true):
@@ -484,7 +485,7 @@ jobs:
             [ -z "$ISSUE_NUM" ] && continue
             COMMENT=$(printf '**Auto-fix blocked for `%s`:** package not available on all target platforms (`%s`) — pin skipped for this image variant.\n```\n%s\n```' \
               "$FAIL_PKG" "$FAIL_PLATFORMS" "$FAIL_MSG")
-            gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "$COMMENT"
+            GH_TOKEN="$GH_ISSUE_TOKEN" gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "$COMMENT"
           done
           rm -rf "$FAIL_DIR"
 
@@ -522,7 +523,7 @@ jobs:
                   TR_ISSUE=$(echo "$OPEN_ISSUES_AF" | jq -r --arg cve "$TR_CVE" \
                     '.[] | select(.title | contains($cve)) | .number' | head -1)
                   [ -z "$TR_ISSUE" ] && continue
-                  gh issue comment "$TR_ISSUE" --repo "$REPO" --body \
+                  GH_TOKEN="$GH_ISSUE_TOKEN" gh issue comment "$TR_ISSUE" --repo "$REPO" --body \
                     "**Auto-fix blocked:** ${TR_CVE} is in a Go module inside the lego binary (not an OS package). The only fix is a lego release that vendors the patched dependency. Lego is already at the latest release (\`${CURRENT_LEGO}\`) which still includes the vulnerable version. No action possible until lego upstream publishes a fix."
                 done
               fi

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -251,6 +251,7 @@ jobs:
           GH_TOKEN: ${{ secrets.CVE_AUTOFIX_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
+          set -x
           # Conditions for auto-fix PR (all must be true):
           # 1. CVE severity is HIGH or CRITICAL
           # 2. A fixed version exists (not "unknown") on at least one affected image

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -251,7 +251,6 @@ jobs:
           GH_TOKEN: ${{ secrets.CVE_AUTOFIX_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          set -x
           # Conditions for auto-fix PR (all must be true):
           # 1. CVE severity is HIGH or CRITICAL
           # 2. A fixed version exists (not "unknown") on at least one affected image
@@ -377,7 +376,7 @@ jobs:
           write_os_pins() {
             local DOCKERFILE="$1" PM="$2" FIXES="$3"
             if [ -z "$FIXES" ]; then
-              grep -q "CVE security pins" "$DOCKERFILE" 2>/dev/null || return
+              grep -q "CVE security pins" "$DOCKERFILE" 2>/dev/null || return 0
               awk '/# --- CVE security pins \(auto-managed\)/{skip=1} /# --- end CVE security pins ---/{skip=0;next} !skip{print}' \
                 "$DOCKERFILE" > "${DOCKERFILE}.tmp" && mv "${DOCKERFILE}.tmp" "$DOCKERFILE"
               return

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -439,8 +439,10 @@ jobs:
                   echo "RUN apk add --no-cache ${PKG_VER}"
                 } > "${TEST_DIR}/Dockerfile"
               fi
+              set +e
               BUILD_LOG=$(docker buildx build --platform "$PLATFORMS" "${TEST_DIR}" 2>&1)
               BUILD_OK=$?
+              set -e
               rm -rf "$TEST_DIR"
               if [ "$BUILD_OK" -eq 0 ]; then
                 VERIFIED="${VERIFIED} ${PKG_VER}"
@@ -491,8 +493,8 @@ jobs:
             RAW_VER=$(echo "$FIXABLE_NGINX" | grep -oE '\([^)]+\)' | head -1 | tr -d '()')
             NGINX_VER=$(echo "$RAW_VER" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
             if [ -n "$NGINX_VER" ]; then
-              sed -i "s|^FROM nginx:[0-9][0-9.]*$|FROM nginx:${NGINX_VER}|" src/Dockerfile
-              sed -i "s|^FROM nginx:[0-9][0-9.]*-alpine|FROM nginx:${NGINX_VER}-alpine|" \
+              sed -i "s|^FROM nginx:[^ ]*|FROM nginx:${NGINX_VER}|" src/Dockerfile
+              sed -i "s|^FROM nginx:[^ ]*-alpine[^ ]*|FROM nginx:${NGINX_VER}-alpine|" \
                 src/Dockerfile-alpine
             fi
           fi

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -62,10 +62,10 @@ RUN chmod +x -R /scripts && \
     sed -ri '/^if \[ "\$1" = "nginx" \] \|\| \[ "\$1" = "nginx-debug" \]; then$/,${s//if echo "$1" | grep -q "nginx"; then/;b};$q1' /docker-entrypoint.sh
 
 # Create a volume to have persistent storage for the obtained certificates.
+
 # --- CVE security pins (auto-managed) ---
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libc-bin=2.41-12+deb13u2 \
-    libc6=2.41-12+deb13u2 \
+    libpng16-16t64=1.6.48-1+deb13u4 \
     && rm -rf /var/lib/apt/lists/*
 # --- end CVE security pins ---
 

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -63,8 +63,9 @@ RUN chmod +x -R /scripts && \
     sed -ri '/^if \[ "\$1" = "nginx" \] \|\| \[ "\$1" = "nginx-debug" \]; then$/,${s//if echo "$1" | grep -q "nginx"; then/;b};$q1' /docker-entrypoint.sh
 
 # Create a volume to have persistent storage for the obtained certificates.
+
 # --- CVE security pins (auto-managed) ---
-RUN apk add --no-cache libexpat=2.7.5-r0 zlib=1.3.2-r0
+RUN apk add --no-cache libpng=1.6.56-r0
 # --- end CVE security pins ---
 
 VOLUME /etc/letsencrypt


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-04-06).

**lego transitive CVEs (gobinary):** lego already at latest (4.33.0); transitive CVEs require an upstream lego release

**OS package CVEs pinned:**  CVE-2026-33416(libpng16-16t64@debian=1.6.48-1+deb13u4) CVE-2026-33636(libpng16-16t64@debian=1.6.48-1+deb13u4) CVE-2026-33416(libpng@alpine=1.6.56-r0) CVE-2026-33636(libpng@alpine=1.6.56-r0)
Fix versions differ by package manager (apt vs apk) — each variant pinned to its own version.