### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-04-12)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -63,9 +63,10 @@ RUN chmod +x -R /scripts && \
 
 # Create a volume to have persistent storage for the obtained certificates.
 
+
 # --- CVE security pins (auto-managed) ---
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libpng16-16t64=1.6.48-1+deb13u4 \
+    libtiff6=4.7.0-3+deb13u2 \
     && rm -rf /var/lib/apt/lists/*
 # --- end CVE security pins ---
 

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -64,9 +64,6 @@ RUN chmod +x -R /scripts && \
 
 # Create a volume to have persistent storage for the obtained certificates.
 
-# --- CVE security pins (auto-managed) ---
-RUN apk add --no-cache libpng=1.6.56-r0
-# --- end CVE security pins ---
 
 VOLUME /etc/letsencrypt
 


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-04-12).

**lego transitive CVEs (gobinary):** lego already at latest (4.33.0); transitive CVEs require an upstream lego release

**OS package CVEs pinned:**  CVE-2026-4775(libtiff6@debian=4.7.0-3+deb13u2)
Fix versions differ by package manager (apt vs apk) — each variant pinned to its own version.

**Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed.