### PR TITLE
Bump nginx from 1.29.7 to 1.29.8

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.29.7@sha256:7150b3a39203cb5bee612ff4a9d18774f8c7caf6399d6e8985e97e28eb751c18
+FROM nginx:1.29.8@sha256:7f0adca1fc6c29c8dc49a2e90037a10ba20dc266baaed0988e9fb4d0d8b85ba0
 LABEL maintainer="emulatorchen"
 
 # FORK: Python/certbot/Rust removed. Only the static lego binary is installed.

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM nginx:1.29.7-alpine@sha256:e7257f1ef28ba17cf7c248cb8ccf6f0c6e0228ab9c315c152f9c203cd34cf6d1
+FROM nginx:1.29.8-alpine@sha256:582c496ccf79d8aa6f8203a79d32aaf7ffd8b13362c60a701a2f9ac64886c93d
 LABEL maintainer="emulatorchen"
 
 # FORK: Python/certbot removed. Only the static lego binary is installed.

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 # When merging lego version bumps: update ARG LEGO_VERSION below.
 # Skip all certbot/Python changes from upstream — they are intentionally removed.
 
-ARG NGINX_VERSION=1.29.7
+ARG NGINX_VERSION=1.29.8
 ARG LEGO_VERSION=4.33.0
 ARG TARGETARCH
 ARG TARGETVARIANT


### PR DESCRIPTION
Automated nginx version bump.

- **From:** `1.29.7`
- **To:** `1.29.8`
- **Release notes:** https://nginx.org/en/CHANGES

This PR was opened automatically by the `check-nginx-update` workflow.
The build CI will validate the new image across all platforms.