### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-04-19)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python/Rust changes — they are intentionally removed.
 
-ARG LEGO_VERSION=4.33.0
+ARG LEGO_VERSION=4.34.0
 ARG TARGETARCH
 ARG TARGETVARIANT
 
@@ -64,9 +64,10 @@ RUN chmod +x -R /scripts && \
 # Create a volume to have persistent storage for the obtained certificates.
 
 
+
 # --- CVE security pins (auto-managed) ---
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libtiff6=4.7.0-3+deb13u2 \
+    libpng16-16t64=1.6.48-1+deb13u4 \
     && rm -rf /var/lib/apt/lists/*
 # --- end CVE security pins ---
 

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python changes — they are intentionally removed.
 
-ARG LEGO_VERSION=4.33.0
+ARG LEGO_VERSION=4.34.0
 ARG TARGETARCH
 ARG TARGETVARIANT
 
@@ -64,6 +64,10 @@ RUN chmod +x -R /scripts && \
 
 # Create a volume to have persistent storage for the obtained certificates.
 
+
+# --- CVE security pins (auto-managed) ---
+RUN apk add --no-cache musl-utils=1.2.5-r23 musl=1.2.5-r23 zlib=1.3.2-r0
+# --- end CVE security pins ---
 
 VOLUME /etc/letsencrypt
 

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -11,7 +11,7 @@ LABEL maintainer="emulatorchen"
 # Skip all certbot/Python changes from upstream — they are intentionally removed.
 
 ARG NGINX_VERSION=1.29.7
-ARG LEGO_VERSION=4.33.0
+ARG LEGO_VERSION=4.34.0
 ARG TARGETARCH
 ARG TARGETVARIANT
 


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-04-19).

**lego transitive CVEs (gobinary):** Bumped lego 4.33.0 → 4.34.0

**OS package CVEs pinned:**  CVE-2026-33416(libpng16-16t64@debian=1.6.48-1+deb13u4) CVE-2026-33636(libpng16-16t64@debian=1.6.48-1+deb13u4) CVE-2026-22184(zlib@alpine=1.3.2-r0) CVE-2026-33416(libpng@alpine=1.6.56-r0) CVE-2026-33636(libpng@alpine=1.6.56-r0) CVE-2026-40200(musl@alpine=1.2.5-r23) CVE-2026-40200(musl-utils@alpine=1.2.5-r23)
Fix versions differ by package manager (apt vs apk) — each variant pinned to its own version.