### PR TITLE
Bump nginx from 1.29.7 to 1.30.0

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.29.7@sha256:7150b3a39203cb5bee612ff4a9d18774f8c7caf6399d6e8985e97e28eb751c18
+FROM nginx:1.30.0@sha256:55d1fb0944aafb8534b253e486c6cf57d3e0c785c4f6a7b3e9f02c5a080fb2ce
 LABEL maintainer="emulatorchen"
 
 # FORK: Python/certbot/Rust removed. Only the static lego binary is installed.

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM nginx:1.29.7-alpine@sha256:e7257f1ef28ba17cf7c248cb8ccf6f0c6e0228ab9c315c152f9c203cd34cf6d1
+FROM nginx:1.30.0-alpine@sha256:0272e4604ed93c1792f03695a033a6e8546840f86e0de20a884bb17d2c924883
 LABEL maintainer="emulatorchen"
 
 # FORK: Python/certbot removed. Only the static lego binary is installed.

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 # When merging lego version bumps: update ARG LEGO_VERSION below.
 # Skip all certbot/Python changes from upstream — they are intentionally removed.
 
-ARG NGINX_VERSION=1.29.7
+ARG NGINX_VERSION=1.30.0
 ARG LEGO_VERSION=4.34.0
 ARG TARGETARCH
 ARG TARGETVARIANT


### PR DESCRIPTION
Automated nginx version bump.

- **From:** `1.29.7`
- **To:** `1.30.0`
- **Release notes:** https://nginx.org/en/CHANGES

This PR was opened automatically by the `check-nginx-update` workflow.
The build CI will validate the new image across all platforms.