### PR TITLE
ci: sandboxed-trivy action, suppress cosign noise, fix Ubuntu nginx stable/mainline

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -64,25 +64,15 @@ jobs:
           push: false
           tags: scan-target:debian
 
-      - name: Install Trivy v0.69.3
-        run: |
-          TRIVY_VERSION="0.69.3"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
-          sha256sum --ignore-missing -c "trivy_${TRIVY_VERSION}_checksums.txt"
-          tar xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          sudo mv trivy /usr/local/bin/trivy
-          rm -f trivy_*
-
       - name: Scan Debian image
-        run: |
-          trivy image \
-            --exit-code 0 \
-            --severity CRITICAL,HIGH \
-            --ignorefile .trivyignore \
-            --format sarif \
-            --output trivy-debian.sarif \
-            scan-target:debian
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: scan-target:debian
+          severity: CRITICAL,HIGH
+          trivyignores: .trivyignore
+          format: sarif
+          output: trivy-debian.sarif
+          exit-code: 0
 
       - name: Upload Debian SARIF
         if: always()
@@ -136,25 +126,15 @@ jobs:
           push: false
           tags: scan-target:alpine
 
-      - name: Install Trivy v0.69.3
-        run: |
-          TRIVY_VERSION="0.69.3"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
-          sha256sum --ignore-missing -c "trivy_${TRIVY_VERSION}_checksums.txt"
-          tar xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          sudo mv trivy /usr/local/bin/trivy
-          rm -f trivy_*
-
       - name: Scan Alpine image
-        run: |
-          trivy image \
-            --exit-code 0 \
-            --severity CRITICAL,HIGH \
-            --ignorefile .trivyignore \
-            --format sarif \
-            --output trivy-alpine.sarif \
-            scan-target:alpine
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: scan-target:alpine
+          severity: CRITICAL,HIGH
+          trivyignores: .trivyignore
+          format: sarif
+          output: trivy-alpine.sarif
+          exit-code: 0
 
       - name: Upload Alpine SARIF
         if: always()
@@ -206,25 +186,15 @@ jobs:
           push: false
           tags: scan-target:ubuntu
 
-      - name: Install Trivy v0.69.3
-        run: |
-          TRIVY_VERSION="0.69.3"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
-          sha256sum --ignore-missing -c "trivy_${TRIVY_VERSION}_checksums.txt"
-          tar xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          sudo mv trivy /usr/local/bin/trivy
-          rm -f trivy_*
-
       - name: Scan Ubuntu image
-        run: |
-          trivy image \
-            --exit-code 0 \
-            --severity CRITICAL,HIGH \
-            --ignorefile .trivyignore \
-            --format sarif \
-            --output trivy-ubuntu.sarif \
-            scan-target:ubuntu
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: scan-target:ubuntu
+          severity: CRITICAL,HIGH
+          trivyignores: .trivyignore
+          format: sarif
+          output: trivy-ubuntu.sarif
+          exit-code: 0
 
       - name: Upload Ubuntu SARIF
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,25 +253,15 @@ jobs:
           push: false
           tags: scan-target:debian
 
-      - name: Install Trivy v0.69.3
-        run: |
-          TRIVY_VERSION="0.69.3"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
-          sha256sum --ignore-missing -c "trivy_${TRIVY_VERSION}_checksums.txt"
-          tar xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          sudo mv trivy /usr/local/bin/trivy
-          rm -f trivy_*
-
       - name: Scan Debian image (block on CRITICAL/HIGH)
-        run: |
-          trivy image \
-            --exit-code 1 \
-            --severity CRITICAL,HIGH \
-            --ignore-unfixed \
-            --ignorefile .trivyignore \
-            --format table \
-            scan-target:debian
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: scan-target:debian
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          format: table
+          exit-code: 1
 
   scan_alpine:
     name: "Scan Alpine image for vulnerabilities"
@@ -297,25 +287,15 @@ jobs:
           push: false
           tags: scan-target:alpine
 
-      - name: Install Trivy v0.69.3
-        run: |
-          TRIVY_VERSION="0.69.3"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
-          sha256sum --ignore-missing -c "trivy_${TRIVY_VERSION}_checksums.txt"
-          tar xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          sudo mv trivy /usr/local/bin/trivy
-          rm -f trivy_*
-
       - name: Scan Alpine image (block on CRITICAL/HIGH)
-        run: |
-          trivy image \
-            --exit-code 1 \
-            --severity CRITICAL,HIGH \
-            --ignore-unfixed \
-            --ignorefile .trivyignore \
-            --format table \
-            scan-target:alpine
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: scan-target:alpine
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          format: table
+          exit-code: 1
 
   scan_ubuntu:
     name: "Scan Ubuntu image for vulnerabilities"
@@ -341,25 +321,15 @@ jobs:
           push: false
           tags: scan-target:ubuntu
 
-      - name: Install Trivy v0.69.3
-        run: |
-          TRIVY_VERSION="0.69.3"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
-          sha256sum --ignore-missing -c "trivy_${TRIVY_VERSION}_checksums.txt"
-          tar xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          sudo mv trivy /usr/local/bin/trivy
-          rm -f trivy_*
-
       - name: Scan Ubuntu image (block on CRITICAL/HIGH)
-        run: |
-          trivy image \
-            --exit-code 1 \
-            --severity CRITICAL,HIGH \
-            --ignore-unfixed \
-            --ignorefile .trivyignore \
-            --format table \
-            scan-target:ubuntu
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: scan-target:ubuntu
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          format: table
+          exit-code: 1
 
   docker_buildx_debian:
     needs: [resolve_tag, security_preflight, integration_check, scan_debian, scan_alpine, scan_ubuntu]
@@ -660,22 +630,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Trivy v0.69.3
-        run: |
-          TRIVY_VERSION="0.69.3"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
-          sha256sum --ignore-missing -c "trivy_${TRIVY_VERSION}_checksums.txt"
-          tar xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          sudo mv trivy /usr/local/bin/trivy
-          rm -f trivy_*
+      - name: Scan Debian released image
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: emulator/docker-nginx-lego:latest
+          trivyignores: .trivyignore
+          format: json
+          output: trivy-debian.json
+          exit-code: 0
 
-      - name: Scan released images
-        run: |
-          BASE="emulator/docker-nginx-lego"
-          trivy image --ignorefile .trivyignore --format json --output trivy-debian.json  "${BASE}:latest"
-          trivy image --ignorefile .trivyignore --format json --output trivy-alpine.json  "${BASE}:latest-alpine"
-          trivy image --ignorefile .trivyignore --format json --output trivy-ubuntu.json  "${BASE}:latest-ubuntu"
+      - name: Scan Alpine released image
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: emulator/docker-nginx-lego:latest-alpine
+          trivyignores: .trivyignore
+          format: json
+          output: trivy-alpine.json
+          exit-code: 0
+
+      - name: Scan Ubuntu released image
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: emulator/docker-nginx-lego:latest-ubuntu
+          trivyignores: .trivyignore
+          format: json
+          output: trivy-ubuntu.json
+          exit-code: 0
 
       - name: Build step summary
         if: always()

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -249,6 +249,7 @@ jobs:
       - name: Create auto-fix PR if applicable
         env:
           GH_TOKEN: ${{ secrets.CVE_AUTOFIX_TOKEN }}
+          GH_ISSUE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           # Conditions for auto-fix PR (all must be true):
@@ -484,7 +485,7 @@ jobs:
             [ -z "$ISSUE_NUM" ] && continue
             COMMENT=$(printf '**Auto-fix blocked for `%s`:** package not available on all target platforms (`%s`) — pin skipped for this image variant.\n```\n%s\n```' \
               "$FAIL_PKG" "$FAIL_PLATFORMS" "$FAIL_MSG")
-            gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "$COMMENT"
+            GH_TOKEN="$GH_ISSUE_TOKEN" gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "$COMMENT"
           done
           rm -rf "$FAIL_DIR"
 
@@ -522,7 +523,7 @@ jobs:
                   TR_ISSUE=$(echo "$OPEN_ISSUES_AF" | jq -r --arg cve "$TR_CVE" \
                     '.[] | select(.title | contains($cve)) | .number' | head -1)
                   [ -z "$TR_ISSUE" ] && continue
-                  gh issue comment "$TR_ISSUE" --repo "$REPO" --body \
+                  GH_TOKEN="$GH_ISSUE_TOKEN" gh issue comment "$TR_ISSUE" --repo "$REPO" --body \
                     "**Auto-fix blocked:** ${TR_CVE} is in a Go module inside the lego binary (not an OS package). The only fix is a lego release that vendors the patched dependency. Lego is already at the latest release (\`${CURRENT_LEGO}\`) which still includes the vulnerable version. No action possible until lego upstream publishes a fix."
                 done
               fi

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -251,6 +251,7 @@ jobs:
           GH_TOKEN: ${{ secrets.CVE_AUTOFIX_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
+          set -x
           # Conditions for auto-fix PR (all must be true):
           # 1. CVE severity is HIGH or CRITICAL
           # 2. A fixed version exists (not "unknown") on at least one affected image

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -251,7 +251,6 @@ jobs:
           GH_TOKEN: ${{ secrets.CVE_AUTOFIX_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          set -x
           # Conditions for auto-fix PR (all must be true):
           # 1. CVE severity is HIGH or CRITICAL
           # 2. A fixed version exists (not "unknown") on at least one affected image
@@ -377,7 +376,7 @@ jobs:
           write_os_pins() {
             local DOCKERFILE="$1" PM="$2" FIXES="$3"
             if [ -z "$FIXES" ]; then
-              grep -q "CVE security pins" "$DOCKERFILE" 2>/dev/null || return
+              grep -q "CVE security pins" "$DOCKERFILE" 2>/dev/null || return 0
               awk '/# --- CVE security pins \(auto-managed\)/{skip=1} /# --- end CVE security pins ---/{skip=0;next} !skip{print}' \
                 "$DOCKERFILE" > "${DOCKERFILE}.tmp" && mv "${DOCKERFILE}.tmp" "$DOCKERFILE"
               return

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -439,8 +439,10 @@ jobs:
                   echo "RUN apk add --no-cache ${PKG_VER}"
                 } > "${TEST_DIR}/Dockerfile"
               fi
+              set +e
               BUILD_LOG=$(docker buildx build --platform "$PLATFORMS" "${TEST_DIR}" 2>&1)
               BUILD_OK=$?
+              set -e
               rm -rf "$TEST_DIR"
               if [ "$BUILD_OK" -eq 0 ]; then
                 VERIFIED="${VERIFIED} ${PKG_VER}"
@@ -491,8 +493,8 @@ jobs:
             RAW_VER=$(echo "$FIXABLE_NGINX" | grep -oE '\([^)]+\)' | head -1 | tr -d '()')
             NGINX_VER=$(echo "$RAW_VER" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
             if [ -n "$NGINX_VER" ]; then
-              sed -i "s|^FROM nginx:[0-9][0-9.]*$|FROM nginx:${NGINX_VER}|" src/Dockerfile
-              sed -i "s|^FROM nginx:[0-9][0-9.]*-alpine|FROM nginx:${NGINX_VER}-alpine|" \
+              sed -i "s|^FROM nginx:[^ ]*|FROM nginx:${NGINX_VER}|" src/Dockerfile
+              sed -i "s|^FROM nginx:[^ ]*-alpine[^ ]*|FROM nginx:${NGINX_VER}-alpine|" \
                 src/Dockerfile-alpine
             fi
           fi

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -36,32 +36,24 @@ jobs:
           push: false
           tags: scan-target:${{ matrix.variant }}
 
-      - name: Install Trivy v0.69.3
-        run: |
-          TRIVY_VERSION="0.69.3"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          curl -sLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
-          sha256sum --ignore-missing -c "trivy_${TRIVY_VERSION}_checksums.txt"
-          tar xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          sudo mv trivy /usr/local/bin/trivy
-          rm -f trivy_*
-
       - name: Scan ${{ matrix.variant }} image (JSON)
-        run: |
-          trivy image \
-            --format json \
-            --output trivy-${{ matrix.variant }}.json \
-            --ignorefile .trivyignore \
-            scan-target:${{ matrix.variant }}
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: scan-target:${{ matrix.variant }}
+          trivyignores: .trivyignore
+          format: json
+          output: trivy-${{ matrix.variant }}.json
+          exit-code: 0
 
       - name: Scan ${{ matrix.variant }} image (SARIF)
         if: always()
-        run: |
-          trivy image \
-            --format sarif \
-            --output trivy-${{ matrix.variant }}.sarif \
-            --ignorefile .trivyignore \
-            scan-target:${{ matrix.variant }}
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+        with:
+          scan-ref: scan-target:${{ matrix.variant }}
+          trivyignores: .trivyignore
+          format: sarif
+          output: trivy-${{ matrix.variant }}.sarif
+          exit-code: 0
 
       - name: Upload SARIF to GitHub Security tab
         if: always()

--- a/.github/workflows/workflow_security.yml
+++ b/.github/workflows/workflow_security.yml
@@ -375,22 +375,26 @@ jobs:
         run: |
           VER="${LEGO_VER}"
 
+          if [ "$AVAILABLE" != "true" ]; then
+            echo "cosign artifacts not available for lego v${VER} — skipping PR comment"
+            CID=$(gh api "repos/${REPO}/issues/${PR}/comments" \
+              --jq '.[] | select(.body | startswith("<!-- workflow-security-lego -->")) | .id' \
+              2>/dev/null | head -1 || true)
+            if [ -n "$CID" ]; then
+              echo "Deleting stale cosign comment (${CID})..."
+              gh api --method DELETE "repos/${REPO}/issues/comments/${CID}" >/dev/null
+            fi
+            exit 0
+          fi
+
           if [ "$CHANGED" = "true" ]; then
-            if [ "$AVAILABLE" = "true" ]; then
-              if [ "$VERIFIED" = "true" ]; then
-                STATUS="✅ cosign signature verified for lego v${VER}"
-              else
-                STATUS="❌ cosign signature **FAILED** for lego v${VER} — do not merge"
-              fi
+            if [ "$VERIFIED" = "true" ]; then
+              STATUS="✅ cosign signature verified for lego v${VER}"
             else
-              STATUS="⚠️ cosign artifacts not published for lego v${VER} (go-acme/lego does not yet sign releases). SHA256 checksum verification still runs at \`docker build\` time."
+              STATUS="❌ cosign signature **FAILED** for lego v${VER} — do not merge"
             fi
           else
-            if [ "$AVAILABLE" = "true" ] && [ "$VERIFIED" = "true" ]; then
-              STATUS="ℹ️ lego version unchanged (v${VER}). Informational cosign check: ✅ signature valid."
-            else
-              STATUS="ℹ️ lego version unchanged (v${VER}). Cosign artifacts not available — no signature check performed."
-            fi
+            STATUS="ℹ️ lego version unchanged (v${VER}). Informational cosign check: ✅ signature valid."
           fi
 
           BODY=$(printf '%s\n\n## lego Binary Signing Check\n\n%s\n' \

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -25,7 +25,7 @@ RUN set -ex && \
 # Add official nginx.org mainline repository for Ubuntu Noble.
     curl -fsSL https://nginx.org/keys/nginx_signing.key \
         | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/mainline/ubuntu noble nginx" \
+    printf 'deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu noble nginx\ndeb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/mainline/ubuntu noble nginx\n' \
         > /etc/apt/sources.list.d/nginx.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

- Replace all manual trivy binary downloads (curl/sha256/tar/mv, repeated 5×) with `lhotari/sandboxed-trivy-action@f01374b` (v1.0.2). Same trivy 0.69.3, adds caching and runs trivy in an isolated container (read-only fs, capabilities dropped, no docker socket).
- Suppress the permanent ⚠️ lego cosign PR comment. go-acme/lego has never published cosign artifacts (`.pem`/`.sig`) for any release — the warning has appeared on every PR since the check was written. The check itself stays and will auto-activate if lego adopts cosign. When artifacts are unavailable the step now logs to stdout and deletes any stale comment.
- Fix `Dockerfile-ubuntu` build failure (PR #67): nginx 1.30.0 is a stable release (even minor) and lives in the stable apt repo, not mainline. Added both repos so any version the automation bumps to is resolvable.

## Test plan

- [ ] `build_latest.yml` — sandboxed-trivy runs, SARIF uploads to Security tab
- [ ] `workflow_security.yml` — no cosign ⚠️ comment appears on PRs
- [ ] `Dockerfile-ubuntu` build passes with `ARG NGINX_VERSION=1.30.0`
- [ ] `scan_vulnerabilities.yml` — manual dispatch, all three matrix variants scan
- [ ] `release.yml` — gate scan jobs (manual dispatch with `skip_security_scan: false`)