### PR TITLE
Bump lego from 4.34.0 to 5.1.0

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python/Rust changes — they are intentionally removed.
 
-ARG LEGO_VERSION=4.34.0
+ARG LEGO_VERSION=5.1.0
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python changes — they are intentionally removed.
 
-ARG LEGO_VERSION=4.34.0
+ARG LEGO_VERSION=5.1.0
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -11,7 +11,7 @@ LABEL maintainer="emulatorchen"
 # Skip all certbot/Python changes from upstream — they are intentionally removed.
 
 ARG NGINX_VERSION=1.31.1
-ARG LEGO_VERSION=4.34.0
+ARG LEGO_VERSION=5.1.0
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/src/scripts/run_lego.sh
+++ b/src/scripts/run_lego.sh
@@ -186,7 +186,7 @@ get_certificate_lego() {
         # HTTP-01 challenge via lego webroot.
         # Must always specify --http.webroot — never use --http alone.
         info "Requesting a ${key_type} certificate for '${cert_name}' (http-01 via lego webroot)"
-        lego \
+        lego ${lego_subcmd} \
             --path       "${LEGO_PATH}" \
             --email      "${CERTBOT_EMAIL}" \
             --server     "${letsencrypt_url}" \
@@ -195,7 +195,7 @@ get_certificate_lego() {
             --key-type   "${key_type}" \
             --accept-tos \
             "${domain_args[@]}" \
-            ${lego_subcmd} "${lego_extra_args[@]}" || return 1
+            "${lego_extra_args[@]}" || return 1
     else
         # DNS-01 challenge.
         local provider="" creds_suffix=""
@@ -222,7 +222,7 @@ get_certificate_lego() {
         # (not from a .ini file) work without a creds file.
 
         info "Requesting a ${key_type} certificate for '${cert_name}' (dns-01 via lego/${dns_provider})"
-        env "${env_args[@]}" lego \
+        env "${env_args[@]}" lego ${lego_subcmd} \
             --path      "${LEGO_PATH}" \
             --email     "${CERTBOT_EMAIL}" \
             --server    "${letsencrypt_url}" \
@@ -230,7 +230,7 @@ get_certificate_lego() {
             --key-type  "${key_type}" \
             --accept-tos \
             "${domain_args[@]}" \
-            ${lego_subcmd} "${lego_extra_args[@]}" || return 1
+            "${lego_extra_args[@]}" || return 1
     fi
 
     # Symlink lego output into certbot-compatible live/<cert_name>/ layout


### PR DESCRIPTION
Automated lego version bump.

- **From:** `4.34.0`
- **To:** `5.1.0`
- **Release notes:** https://github.com/go-acme/lego/releases/tag/v5.1.0

This PR was opened automatically by the `check-lego-update` workflow.
The build CI will validate the new binary across all platforms.