### PR TITLE
Bump nginx from 1.31.0 to 1.31.1

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.31.0@sha256:06aa3d7be10bc6307990c81bdca075793132e9163391abc370c015e344e23128
+FROM nginx:1.31.1@sha256:5aca99593157f4ae539a5dec1092a0ad8762f8e2eb1789085a13a0f5622369f6
 LABEL maintainer="emulatorchen"
 
 # FORK: Python/certbot/Rust removed. Only the static lego binary is installed.

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM nginx:1.31.0-alpine@sha256:dc48b7a872a79fb541ba5081d320b11b549231bc63ba465a7495afaa7d2ebcb8
+FROM nginx:1.31.1-alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a
 LABEL maintainer="emulatorchen"
 
 # FORK: Python/certbot removed. Only the static lego binary is installed.

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 # When merging lego version bumps: update ARG LEGO_VERSION below.
 # Skip all certbot/Python changes from upstream — they are intentionally removed.
 
-ARG NGINX_VERSION=1.31.0
+ARG NGINX_VERSION=1.31.1
 ARG LEGO_VERSION=4.34.0
 ARG TARGETARCH
 ARG TARGETVARIANT


### PR DESCRIPTION
Automated nginx version bump.

- **From:** `1.31.0`
- **To:** `1.31.1`
- **Release notes:** https://nginx.org/en/CHANGES

This PR was opened automatically by the `check-nginx-update` workflow.
The build CI will validate the new image across all platforms.