### PR TITLE
fix: scan-vulnerabilities triage step exits 1 on open security PRs

### DIFF
--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -116,9 +116,10 @@ jobs:
             echo "$ALL_CVES" | grep -qx "$CVE_ID" && continue
             ISSUE_NUM=$(echo "$OPEN_ISSUES" | jq -r --arg cve "$CVE_ID" \
               '.[] | select(.title | contains($cve)) | .number' | head -1)
-            [ -n "$ISSUE_NUM" ] && \
+            if [ -n "$ISSUE_NUM" ]; then
               gh issue close "$ISSUE_NUM" --repo "$REPO" \
                 --comment "Resolved — ${CVE_ID} no longer detected in weekly scan (${TODAY})."
+            fi
           done
 
           # Close auto-fix PRs where all CVEs in the PR body are resolved
@@ -132,9 +133,10 @@ jobs:
               [ -z "$PR_CVE" ] && continue
               echo "$ALL_CVES" | grep -qx "$PR_CVE" && { ALL_RESOLVED=false; break; }
             done <<< "$PR_CVES"
-            $ALL_RESOLVED && \
+            if [ "$ALL_RESOLVED" = true ]; then
               gh pr close "$PR_NUM" --repo "$REPO" \
                 --comment "All CVEs in this PR are resolved — closing automatically (${TODAY})."
+            fi
           done
 
           if [ -z "$ALL_CVES" ]; then
@@ -532,22 +534,45 @@ jobs:
           git push origin "$BRANCH"
 
           PR_BODY="Auto-fix PR for CVEs detected in weekly vulnerability scan (${TODAY})."
-          [ -n "$FIXABLE_NGINX" ] && PR_BODY="${PR_BODY}
 
-          **nginx CVEs fixed:** ${FIXABLE_NGINX}"
-          [ -n "$FIXABLE_LEGO" ] && PR_BODY="${PR_BODY}
+          if [ -n "$FIXABLE_NGINX" ]; then
+            NGINX_LIST=$(printf '%s\n' $FIXABLE_NGINX | \
+              sed 's/\([^(]*\)(\(.*\))/- `\1` → nginx `\2`/')
+            PR_BODY="${PR_BODY}
 
-          **lego CVEs fixed:** ${FIXABLE_LEGO}"
-          [ -n "$LEGO_TRANSITIVE_CVES" ] && PR_BODY="${PR_BODY}
+**nginx CVEs fixed:**
+${NGINX_LIST}"
+          fi
 
-          **lego transitive CVEs (gobinary):** ${LEGO_NOTE}"
-          [ -n "$FIXABLE_OS_ITEMS" ] && PR_BODY="${PR_BODY}
+          if [ -n "$FIXABLE_LEGO" ]; then
+            LEGO_LIST=$(printf '%s\n' $FIXABLE_LEGO | \
+              sed 's/\([^(]*\)(\(.*\))/- `\1` → lego `\2`/')
+            PR_BODY="${PR_BODY}
 
-          **OS package CVEs pinned:** ${FIXABLE_OS_ITEMS}
-          Fix versions differ by package manager (apt vs apk) — each variant pinned to its own version."
-          $NEEDS_CLEANUP && PR_BODY="${PR_BODY}
+**lego CVEs fixed:**
+${LEGO_LIST}"
+          fi
 
-          **Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed."
+          if [ -n "$LEGO_TRANSITIVE_CVES" ]; then
+            PR_BODY="${PR_BODY}
+
+**lego transitive CVEs (gobinary):** ${LEGO_NOTE}"
+          fi
+
+          if [ -n "$FIXABLE_OS_ITEMS" ]; then
+            OS_LIST=$(printf '%s\n' $FIXABLE_OS_ITEMS | \
+              sed 's/\([^(]*\)(\([^@]*\)@\([^=]*\)=\(.*\))/- `\1` — \2 (\3) → `\4`/')
+            PR_BODY="${PR_BODY}
+
+**OS package CVEs pinned:**
+${OS_LIST}"
+          fi
+
+          if $NEEDS_CLEANUP; then
+            PR_BODY="${PR_BODY}
+
+**Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed."
+          fi
 
           gh pr create \
             --title "fix: auto-fix CVEs from vulnerability scan (${TODAY})" \

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -533,49 +533,39 @@ jobs:
           git commit -m "fix: auto-fix CVEs from vulnerability scan (${TODAY})"
           git push origin "$BRANCH"
 
-          PR_BODY="Auto-fix PR for CVEs detected in weekly vulnerability scan (${TODAY})."
-
+          PR_BODY_FILE=$(mktemp)
+          printf '%s\n' \
+            "Auto-fix PR for CVEs detected in weekly vulnerability scan (${TODAY})." \
+            > "$PR_BODY_FILE"
           if [ -n "$FIXABLE_NGINX" ]; then
-            NGINX_LIST=$(printf '%s\n' $FIXABLE_NGINX | \
-              sed 's/\([^(]*\)(\(.*\))/- `\1` → nginx `\2`/')
-            PR_BODY="${PR_BODY}
-
-**nginx CVEs fixed:**
-${NGINX_LIST}"
+            printf '\n**nginx CVEs fixed:**\n' >> "$PR_BODY_FILE"
+            printf '%s\n' $FIXABLE_NGINX \
+              | sed 's/\([^(]*\)(\(.*\))/- `\1` → nginx `\2`/' \
+              >> "$PR_BODY_FILE"
           fi
-
           if [ -n "$FIXABLE_LEGO" ]; then
-            LEGO_LIST=$(printf '%s\n' $FIXABLE_LEGO | \
-              sed 's/\([^(]*\)(\(.*\))/- `\1` → lego `\2`/')
-            PR_BODY="${PR_BODY}
-
-**lego CVEs fixed:**
-${LEGO_LIST}"
+            printf '\n**lego CVEs fixed:**\n' >> "$PR_BODY_FILE"
+            printf '%s\n' $FIXABLE_LEGO \
+              | sed 's/\([^(]*\)(\(.*\))/- `\1` → lego `\2`/' \
+              >> "$PR_BODY_FILE"
           fi
-
           if [ -n "$LEGO_TRANSITIVE_CVES" ]; then
-            PR_BODY="${PR_BODY}
-
-**lego transitive CVEs (gobinary):** ${LEGO_NOTE}"
+            printf '\n**lego transitive CVEs (gobinary):** %s\n' \
+              "$LEGO_NOTE" >> "$PR_BODY_FILE"
           fi
-
           if [ -n "$FIXABLE_OS_ITEMS" ]; then
-            OS_LIST=$(printf '%s\n' $FIXABLE_OS_ITEMS | \
-              sed 's/\([^(]*\)(\([^@]*\)@\([^=]*\)=\(.*\))/- `\1` — \2 (\3) → `\4`/')
-            PR_BODY="${PR_BODY}
-
-**OS package CVEs pinned:**
-${OS_LIST}"
+            printf '\n**OS package CVEs pinned:**\n' >> "$PR_BODY_FILE"
+            printf '%s\n' $FIXABLE_OS_ITEMS \
+              | sed 's/\([^(]*\)(\([^@]*\)@\([^=]*\)=\(.*\))/- `\1` — \2 (\3) → `\4`/' \
+              >> "$PR_BODY_FILE"
           fi
-
           if $NEEDS_CLEANUP; then
-            PR_BODY="${PR_BODY}
-
-**Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed."
+            printf '\n**Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed.\n' \
+              >> "$PR_BODY_FILE"
           fi
-
           gh pr create \
             --title "fix: auto-fix CVEs from vulnerability scan (${TODAY})" \
-            --body "$PR_BODY" \
+            --body "$(cat "$PR_BODY_FILE")" \
             --base master \
             --label security
+          rm -f "$PR_BODY_FILE"


### PR DESCRIPTION
## Root cause

`$ALL_RESOLVED && gh pr close ...` — when `ALL_RESOLVED=false`, running `false &&` as a compound returns 1 in a piped `while` subshell. With GitHub Actions' bash `-e -o pipefail`, that exits the subshell, the pipeline returns 1, and the triage step fails before any issue creation runs.

This is why the May 25 run closed 6 resolved issues then immediately exited 1 with no output from the issue-creation loop.

## Fixes

- `$ALL_RESOLVED && gh pr close` → `if [ "$ALL_RESOLVED" = true ]; then`
- `[ -n "$ISSUE_NUM" ] && gh issue close` → `if [ -n "$ISSUE_NUM" ]; then`
- `$NEEDS_CLEANUP && PR_BODY=...` → `if $NEEDS_CLEANUP; then`

## Also: PR body formatting

Reformats auto-fix PR body OS package CVEs from a dense space-separated blob into a markdown bullet list, with versions wrapped in backticks. This also fixes a rendering bug: version strings containing `~` (e.g. `257.13-1~deb13u1`) paired with another `~` in a subsequent entry were rendered as ~~strikethrough~~ by GitHub Markdown.