### PR TITLE
fix: scan workflow triage exit 1; release cleanup approval confusion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -745,12 +745,11 @@ jobs:
             fi
           done
 
-  cleanup:
-    name: "Revert release on failure or cancellation"
+  cleanup_git:
+    name: "Delete git tag on failure or cancellation"
     needs: [resolve_tag, release_gate, docker_buildx_debian, docker_buildx_alpine, docker_buildx_ubuntu]
     if: failure() || cancelled()
     runs-on: ubuntu-latest
-    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -761,6 +760,38 @@ jobs:
           [ -z "$TAG" ] && { echo "No tag to delete"; exit 0; }
           git push origin --delete "$TAG" || echo "Tag $TAG not found or already deleted"
 
+  cleanup_notice:
+    name: "Pending: approve to delete Docker Hub tags"
+    needs: [resolve_tag, cleanup_git]
+    if: always() && (needs.resolve_tag.result == 'success') && (needs.cleanup_git.result == 'success' || needs.cleanup_git.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain pending approval
+        run: |
+          L="${{ needs.resolve_tag.outputs.lego }}"
+          N="${{ needs.resolve_tag.outputs.nginx }}"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Action required: approve Docker Hub tag deletion
+
+          The release failed or was cancelled. The git tag has already been deleted.
+
+          **The next approval step is to DELETE partially-pushed Docker Hub tags — it is NOT a new release attempt.**
+
+          Tags that will be deleted (if they exist):
+          - \`lego${L}-nginx${N}\`, \`lego${L}\`, \`latest\`
+          - \`lego${L}-nginx${N}-alpine\`, \`lego${L}-alpine\`, \`latest-alpine\`
+          - \`lego${L}-nginx${N}-ubuntu\`, \`lego${L}-ubuntu\`, \`latest-ubuntu\`
+
+          Click **Review deployments** → select **release** → **Approve and deploy** to proceed with deletion.
+          EOF
+
+  cleanup_dockerhub:
+    name: "⚠️ Approve to DELETE Docker Hub tags — NOT a release"
+    needs: [resolve_tag, cleanup_notice]
+    if: always() && (needs.resolve_tag.result == 'success') && (needs.cleanup_notice.result == 'success')
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
       - name: Delete Docker Hub tags
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -116,9 +116,10 @@ jobs:
             echo "$ALL_CVES" | grep -qx "$CVE_ID" && continue
             ISSUE_NUM=$(echo "$OPEN_ISSUES" | jq -r --arg cve "$CVE_ID" \
               '.[] | select(.title | contains($cve)) | .number' | head -1)
-            [ -n "$ISSUE_NUM" ] && \
+            if [ -n "$ISSUE_NUM" ]; then
               gh issue close "$ISSUE_NUM" --repo "$REPO" \
                 --comment "Resolved — ${CVE_ID} no longer detected in weekly scan (${TODAY})."
+            fi
           done
 
           # Close auto-fix PRs where all CVEs in the PR body are resolved
@@ -132,9 +133,10 @@ jobs:
               [ -z "$PR_CVE" ] && continue
               echo "$ALL_CVES" | grep -qx "$PR_CVE" && { ALL_RESOLVED=false; break; }
             done <<< "$PR_CVES"
-            $ALL_RESOLVED && \
+            if [ "$ALL_RESOLVED" = true ]; then
               gh pr close "$PR_NUM" --repo "$REPO" \
                 --comment "All CVEs in this PR are resolved — closing automatically (${TODAY})."
+            fi
           done
 
           if [ -z "$ALL_CVES" ]; then
@@ -531,26 +533,39 @@ jobs:
           git commit -m "fix: auto-fix CVEs from vulnerability scan (${TODAY})"
           git push origin "$BRANCH"
 
-          PR_BODY="Auto-fix PR for CVEs detected in weekly vulnerability scan (${TODAY})."
-          [ -n "$FIXABLE_NGINX" ] && PR_BODY="${PR_BODY}
-
-          **nginx CVEs fixed:** ${FIXABLE_NGINX}"
-          [ -n "$FIXABLE_LEGO" ] && PR_BODY="${PR_BODY}
-
-          **lego CVEs fixed:** ${FIXABLE_LEGO}"
-          [ -n "$LEGO_TRANSITIVE_CVES" ] && PR_BODY="${PR_BODY}
-
-          **lego transitive CVEs (gobinary):** ${LEGO_NOTE}"
-          [ -n "$FIXABLE_OS_ITEMS" ] && PR_BODY="${PR_BODY}
-
-          **OS package CVEs pinned:** ${FIXABLE_OS_ITEMS}
-          Fix versions differ by package manager (apt vs apk) — each variant pinned to its own version."
-          $NEEDS_CLEANUP && PR_BODY="${PR_BODY}
-
-          **Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed."
-
+          PR_BODY_FILE=$(mktemp)
+          printf '%s\n' \
+            "Auto-fix PR for CVEs detected in weekly vulnerability scan (${TODAY})." \
+            > "$PR_BODY_FILE"
+          if [ -n "$FIXABLE_NGINX" ]; then
+            printf '\n**nginx CVEs fixed:**\n' >> "$PR_BODY_FILE"
+            printf '%s\n' $FIXABLE_NGINX \
+              | sed 's/\([^(]*\)(\(.*\))/- `\1` → nginx `\2`/' \
+              >> "$PR_BODY_FILE"
+          fi
+          if [ -n "$FIXABLE_LEGO" ]; then
+            printf '\n**lego CVEs fixed:**\n' >> "$PR_BODY_FILE"
+            printf '%s\n' $FIXABLE_LEGO \
+              | sed 's/\([^(]*\)(\(.*\))/- `\1` → lego `\2`/' \
+              >> "$PR_BODY_FILE"
+          fi
+          if [ -n "$LEGO_TRANSITIVE_CVES" ]; then
+            printf '\n**lego transitive CVEs (gobinary):** %s\n' \
+              "$LEGO_NOTE" >> "$PR_BODY_FILE"
+          fi
+          if [ -n "$FIXABLE_OS_ITEMS" ]; then
+            printf '\n**OS package CVEs pinned:**\n' >> "$PR_BODY_FILE"
+            printf '%s\n' $FIXABLE_OS_ITEMS \
+              | sed 's/\([^(]*\)(\([^@]*\)@\([^=]*\)=\(.*\))/- `\1` — \2 (\3) → `\4`/' \
+              >> "$PR_BODY_FILE"
+          fi
+          if $NEEDS_CLEANUP; then
+            printf '\n**Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed.\n' \
+              >> "$PR_BODY_FILE"
+          fi
           gh pr create \
             --title "fix: auto-fix CVEs from vulnerability scan (${TODAY})" \
-            --body "$PR_BODY" \
+            --body "$(cat "$PR_BODY_FILE")" \
             --base master \
             --label security
+          rm -f "$PR_BODY_FILE"


### PR DESCRIPTION
## Summary

- **scan_vulnerabilities.yml**: `$bool && command` patterns replaced with `if-then-fi` — `false && gh pr close` was returning 1 inside a piped `while` subshell, causing the step to fail under `bash -e -o pipefail` before any issue creation ran. PR body rewritten to use a temp file (fixes YAML block-scalar indentation issues and prevents tilde in Debian version strings like `1~deb13u1` from rendering as strikethrough markdown).

- **release.yml**: cleanup split into three sequential jobs:
  1. `cleanup_git` — no environment gate, deletes the git tag immediately on failure/cancel
  2. `cleanup_notice` — writes a step summary explaining that the next approval is for **deletion**, not a new release
  3. `⚠️ Approve to DELETE Docker Hub tags — NOT a release` — the renamed `cleanup_dockerhub` job with the `release` environment gate

## Test plan

- [x] Branch `fix/scan-workflow-pipefail` (PR #96) CI passed — scan workflow changes are identical
- [ ] Release workflow cleanup path requires a failed release run to validate end-to-end

## Note

Supersedes PR #96 (`fix/scan-workflow-pipefail`) — please close that PR after merging this one.