### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-05-26)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -69,13 +69,6 @@ RUN chmod +x -R /scripts && \
 
 
 
-# --- CVE security pins (auto-managed) ---
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libsystemd0=257.13-1~deb13u1 \
-    libtiff6=4.7.0-3+deb13u2 \
-    libudev1=257.13-1~deb13u1 \
-    && rm -rf /var/lib/apt/lists/*
-# --- end CVE security pins ---
 
 VOLUME /etc/letsencrypt
 


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-05-26).

**Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed.