### PR TITLE
Bump lego from 5.0.4 to 5.2.1

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python/Rust changes — they are intentionally removed.
 
-ARG LEGO_VERSION=5.0.4
+ARG LEGO_VERSION=5.2.1
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python changes — they are intentionally removed.
 
-ARG LEGO_VERSION=5.0.4
+ARG LEGO_VERSION=5.2.1
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -11,7 +11,7 @@ LABEL maintainer="emulatorchen"
 # Skip all certbot/Python changes from upstream — they are intentionally removed.
 
 ARG NGINX_VERSION=1.31.1
-ARG LEGO_VERSION=5.0.4
+ARG LEGO_VERSION=5.2.1
 ARG TARGETARCH
 ARG TARGETVARIANT
 


### PR DESCRIPTION
Automated lego version bump.

- **From:** `5.0.4`
- **To:** `5.2.1`
- **Release notes:** https://github.com/go-acme/lego/releases/tag/v5.2.1

This PR was opened automatically by the `check-lego-update` workflow.
The build CI will validate the new binary across all platforms.