### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-06-03)

### DIFF
--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -68,6 +68,10 @@ RUN chmod +x -R /scripts && \
 
 
 
+# --- CVE security pins (auto-managed) ---
+RUN apk add --no-cache libxml2=2.13.9-r1
+# --- end CVE security pins ---
+
 VOLUME /etc/letsencrypt
 
 # The Nginx parent Docker image already expose port 80, so we only need to add


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-06-03).

**OS package CVEs pinned:**
- `CVE-2026-6732` — libxml2 (alpine) → `2.13.9-r1`