### PR TITLE
ci: harden security-tool downloads against transient failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install zizmor v1.23.1
         run: |
-          curl -sLo zizmor.tar.gz \
+          curl -fsSL --retry 3 --retry-all-errors -o zizmor.tar.gz \
             "https://github.com/zizmorcore/zizmor/releases/download/v1.23.1/zizmor-x86_64-unknown-linux-gnu.tar.gz"
           echo "67a8df0a14352dd81882e14876653d097b99b0f4f6b6fe798edc0320cff27aff  zizmor.tar.gz" | sha256sum -c -
           tar xzf zizmor.tar.gz
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install actionlint v1.7.12
         run: |
-          curl -sLo actionlint.tar.gz \
+          curl -fsSL --retry 3 --retry-all-errors -o actionlint.tar.gz \
             "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz" | sha256sum -c -
           tar xzf actionlint.tar.gz actionlint

--- a/.github/workflows/workflow_security.yml
+++ b/.github/workflows/workflow_security.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install zizmor v1.23.1
         run: |
-          curl -sLo zizmor.tar.gz \
+          curl -fsSL --retry 3 --retry-all-errors -o zizmor.tar.gz \
             "https://github.com/zizmorcore/zizmor/releases/download/v1.23.1/zizmor-x86_64-unknown-linux-gnu.tar.gz"
           echo "67a8df0a14352dd81882e14876653d097b99b0f4f6b6fe798edc0320cff27aff  zizmor.tar.gz" | sha256sum -c -
           tar xzf zizmor.tar.gz
@@ -179,7 +179,7 @@ jobs:
 
       - name: Install actionlint v1.7.12
         run: |
-          curl -sLo actionlint.tar.gz \
+          curl -fsSL --retry 3 --retry-all-errors -o actionlint.tar.gz \
             "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz" | sha256sum -c -
           tar xzf actionlint.tar.gz actionlint
@@ -330,7 +330,7 @@ jobs:
       - name: Install cosign v3.0.5
         if: steps.cosign_check.outputs.available == 'true'
         run: |
-          curl -sLo cosign \
+          curl -fsSL --retry 3 --retry-all-errors -o cosign \
             "https://github.com/sigstore/cosign/releases/download/v3.0.5/cosign-linux-amd64"
           echo "db15cc99e6e4837daabab023742aaddc3841ce57f193d11b7c3e06c8003642b2  cosign" | sha256sum -c -
           sudo mv cosign /usr/local/bin/cosign
@@ -344,9 +344,9 @@ jobs:
         run: |
           VER="${LEGO_VER}"
           BASE="https://github.com/go-acme/lego/releases/download/v${VER}"
-          curl -sLo /tmp/lego_checksums.txt "${BASE}/lego_v${VER}_checksums.txt"
-          curl -sLo /tmp/lego_checksums.pem "${BASE}/lego_v${VER}_checksums.txt.pem"
-          curl -sLo /tmp/lego_checksums.sig "${BASE}/lego_v${VER}_checksums.txt.sig"
+          curl -fsSL --retry 3 --retry-all-errors -o /tmp/lego_checksums.txt "${BASE}/lego_v${VER}_checksums.txt"
+          curl -fsSL --retry 3 --retry-all-errors -o /tmp/lego_checksums.pem "${BASE}/lego_v${VER}_checksums.txt.pem"
+          curl -fsSL --retry 3 --retry-all-errors -o /tmp/lego_checksums.sig "${BASE}/lego_v${VER}_checksums.txt.sig"
 
           if cosign verify-blob \
             --certificate /tmp/lego_checksums.pem \


### PR DESCRIPTION
## Why

The latest release was blocked by the security gate (and `workflow-security` on master failed) with:
```
sha256sum: WARNING: 1 computed checksum did NOT match
zizmor.tar.gz: FAILED
```

The pinned checksum is **correct** — verified against zizmor's official GitHub release digest for v1.23.1 (`67a8df0a…`). The problem is the download: `curl -sLo` has no `-f` and no retry, so a transient HTTP error (rate limit / 503 / partial body) gets written into `zizmor.tar.gz`, the checksum then fails, the tool never installs, and the gate fails. This is the same transient-download class that has bitten the pipeline repeatedly.

## What

Add `-f --retry 3 --retry-all-errors` to every binary-with-checksum download in the security/release workflows:
- zizmor (`release.yml`, `workflow_security.yml`)
- actionlint (`release.yml`, `workflow_security.yml`)
- cosign (`workflow_security.yml`)
- lego checksum files (`workflow_security.yml`)

`-f` makes curl fail on HTTP errors instead of saving the error body; `--retry`/`--retry-all-errors` transparently retries transient failures. Pins are unchanged.

Out of scope: plain JSON/API `curl`s in the version-check workflows — they don't have the corrupt-file-blocks-gate failure mode.

## Test plan

- [x] Both workflows parse as valid YAML
- [x] zizmor checksum confirmed correct vs official release digest (so this is purely a download-robustness fix)

## Note

This is unrelated to the merged release-tag fix (#123). The release that just failed did not reach the build stage — it was blocked at the security preflight by this download flake.