### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-06-14)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python/Rust changes — they are intentionally removed.
 
-ARG LEGO_VERSION=5.2.1
+ARG LEGO_VERSION=5.2.2
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python changes — they are intentionally removed.
 
-ARG LEGO_VERSION=5.2.1
+ARG LEGO_VERSION=5.2.2
 ARG TARGETARCH
 ARG TARGETVARIANT
 
@@ -68,9 +68,6 @@ RUN chmod +x -R /scripts && \
 
 
 
-# --- CVE security pins (auto-managed) ---
-RUN apk add --no-cache libxml2=2.13.9-r1
-# --- end CVE security pins ---
 
 VOLUME /etc/letsencrypt
 

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -11,7 +11,7 @@ LABEL maintainer="emulatorchen"
 # Skip all certbot/Python changes from upstream — they are intentionally removed.
 
 ARG NGINX_VERSION=1.31.1
-ARG LEGO_VERSION=5.2.1
+ARG LEGO_VERSION=5.2.2
 ARG TARGETARCH
 ARG TARGETVARIANT
 


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-06-14).

**lego transitive CVEs (gobinary):** Bumped lego 5.2.1 → 5.2.2

**Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed.