### PR TITLE
fix: scan opens duplicate auto-fix PRs for non-CVE fix types

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -24,6 +24,8 @@ jobs:
       dockerfiles: ${{ steps.filter.outputs.dockerfiles }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter

--- a/.github/workflows/check_lego_update.yml
+++ b/.github/workflows/check_lego_update.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get latest lego release
         id: latest
@@ -34,19 +36,23 @@ jobs:
 
       - name: Compare versions
         id: compare
+        env:
+          LATEST: ${{ steps.latest.outputs.version }}
+          PINNED: ${{ steps.pinned.outputs.version }}
         run: |
-          if [ "${{ steps.latest.outputs.version }}" = "${{ steps.pinned.outputs.version }}" ]; then
+          if [ "$LATEST" = "$PINNED" ]; then
             echo "up_to_date=true" >> $GITHUB_OUTPUT
-            echo "lego is up to date (${PINNED})"
+            echo "lego is up to date ($PINNED)"
           else
             echo "up_to_date=false" >> $GITHUB_OUTPUT
-            echo "New lego version available: ${{ steps.latest.outputs.version }} (current: ${{ steps.pinned.outputs.version }})"
+            echo "New lego version available: $LATEST (current: $PINNED)"
           fi
 
       - name: Update LEGO_VERSION in Dockerfiles
         if: steps.compare.outputs.up_to_date == 'false'
+        env:
+          NEW: ${{ steps.latest.outputs.version }}
         run: |
-          NEW="${{ steps.latest.outputs.version }}"
           sed -i "s/ARG LEGO_VERSION=.*/ARG LEGO_VERSION=${NEW}/" src/Dockerfile
           sed -i "s/ARG LEGO_VERSION=.*/ARG LEGO_VERSION=${NEW}/" src/Dockerfile-alpine
           sed -i "s/ARG LEGO_VERSION=.*/ARG LEGO_VERSION=${NEW}/" src/Dockerfile-ubuntu

--- a/.github/workflows/check_nginx_update.yml
+++ b/.github/workflows/check_nginx_update.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get latest nginx release
         id: latest
@@ -38,19 +40,23 @@ jobs:
 
       - name: Compare versions
         id: compare
+        env:
+          LATEST: ${{ steps.latest.outputs.version }}
+          PINNED: ${{ steps.pinned.outputs.version }}
         run: |
-          if [ "${{ steps.latest.outputs.version }}" = "${{ steps.pinned.outputs.version }}" ]; then
+          if [ "$LATEST" = "$PINNED" ]; then
             echo "up_to_date=true" >> $GITHUB_OUTPUT
-            echo "nginx is up to date (${{ steps.pinned.outputs.version }})"
+            echo "nginx is up to date ($PINNED)"
           else
             echo "up_to_date=false" >> $GITHUB_OUTPUT
-            echo "New nginx version available: ${{ steps.latest.outputs.version }} (current: ${{ steps.pinned.outputs.version }})"
+            echo "New nginx version available: $LATEST (current: $PINNED)"
           fi
 
       - name: Update nginx version in Dockerfiles
         if: steps.compare.outputs.up_to_date == 'false'
+        env:
+          NEW: ${{ steps.latest.outputs.version }}
         run: |
-          NEW="${{ steps.latest.outputs.version }}"
           DIGEST=$(docker buildx imagetools inspect "nginx:${NEW}" --format '{{json .Manifest}}' | jq -r .digest)
           ALPINE_DIGEST=$(docker buildx imagetools inspect "nginx:${NEW}-alpine" --format '{{json .Manifest}}' | jq -r .digest)
           sed -i "s|^FROM nginx:.*|FROM nginx:${NEW}@${DIGEST}|" src/Dockerfile

--- a/.github/workflows/check_upstream_update.yml
+++ b/.github/workflows/check_upstream_update.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get last synced upstream ref
         id: synced
@@ -46,9 +48,10 @@ jobs:
 
       - name: Compare refs
         id: compare
+        env:
+          SYNCED: ${{ steps.synced.outputs.ref }}
+          LATEST: ${{ steps.upstream.outputs.tag }}
         run: |
-          SYNCED="${{ steps.synced.outputs.ref }}"
-          LATEST="${{ steps.upstream.outputs.tag }}"
           # Strip leading 'v' for semver comparison
           SYNCED_V=$(echo "$SYNCED" | sed 's/^v//')
           LATEST_V=$(echo "$LATEST" | sed 's/^v//')
@@ -66,8 +69,11 @@ jobs:
       - name: Check for existing open issue
         if: steps.compare.outputs.up_to_date == 'false'
         id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.upstream.outputs.tag }}
         run: |
-          TITLE="Upstream sync: ${{ steps.upstream.outputs.tag }} available"
+          TITLE="Upstream sync: ${TAG} available"
           EXISTS=$(gh issue list \
             --repo "$GITHUB_REPOSITORY" \
             --label "upstream-sync" \
@@ -77,12 +83,10 @@ jobs:
             | head -1)
           if [ -n "$EXISTS" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Issue already open for ${{ steps.upstream.outputs.tag }}, skipping"
+            echo "Issue already open for ${TAG}, skipping"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create upstream-sync label if missing
         if: steps.compare.outputs.up_to_date == 'false' && steps.existing.outputs.exists == 'false'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@cb06a0a8527b2c6970741b3a0baa15231dc74a4c # v4.34.1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,6 +28,8 @@ jobs:
       src: ${{ steps.filter.outputs.src }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
@@ -60,6 +62,8 @@ jobs:
       - name: Checkout
         if: steps.check.outputs.skip != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install zizmor v1.23.1
         run: |
@@ -150,6 +152,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -238,6 +242,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -272,6 +278,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -306,6 +314,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -579,6 +589,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Create GitHub release (auto-generated notes)
         if: inputs.notes == '' && !inputs.override_notes
@@ -649,6 +661,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Scan Debian released image
         uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -602,7 +602,7 @@ jobs:
           else
             generated=""
           fi
-          body="${{ inputs.notes }}"
+          body="$NOTES"
           [ -n "$generated" ] && body="${body}"$'\n\n'"${generated}"
           gh release create "${{ needs.resolve_tag.outputs.tag }}" \
               --title "${{ needs.resolve_tag.outputs.tag }}" \
@@ -610,16 +610,18 @@ jobs:
               --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTES: ${{ inputs.notes }}
 
       - name: Create GitHub release (override notes)
         if: inputs.override_notes
         run: |
           gh release create "${{ needs.resolve_tag.outputs.tag }}" \
               --title "${{ needs.resolve_tag.outputs.tag }}" \
-              --notes "${{ inputs.notes }}" \
+              --notes "$NOTES" \
               --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTES: ${{ inputs.notes }}
 
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -530,6 +530,30 @@ jobs:
             echo "No Dockerfile changes to commit — skipping PR."
             exit 0
           fi
+
+          # Dedup across scan cycles: if an open security PR already proposes the
+          # exact same Dockerfile contents, don't open a duplicate. The CVE-ID
+          # dedup above is blind to fix types that emit no CVE ID in the body
+          # (lego version bumps, stale-pin removals), which otherwise produce a
+          # fresh identical PR on every scan.
+          for existing in $(gh pr list --repo "$REPO" --label security --state open \
+                            --json number --jq '.[].number'); do
+            ref=$(gh pr view "$existing" --repo "$REPO" --json headRefName --jq '.headRefName')
+            identical=true
+            for f in src/Dockerfile src/Dockerfile-alpine src/Dockerfile-ubuntu; do
+              remote=$(gh api "repos/${REPO}/contents/${f}?ref=${ref}" \
+                       --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+              if [ "$remote" != "$(cat "$f")" ]; then
+                identical=false
+                break
+              fi
+            done
+            if [ "$identical" = true ]; then
+              echo "Open security PR #${existing} already proposes these exact changes — skipping."
+              exit 0
+            fi
+          done
+
           git commit -m "fix: auto-fix CVEs from vulnerability scan (${TODAY})"
           git push origin "$BRANCH"
 

--- a/.github/workflows/scan_vulnerabilities.yml
+++ b/.github/workflows/scan_vulnerabilities.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build ${{ matrix.variant }} image for scanning
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -81,6 +83,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download scan artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run BATS tests
         uses: ffurrer2/bats-action@a9be970594050d0c1fac81f8d35ac92c387a9b9e # v1.1.0

--- a/.github/workflows/update_dockerhub_description.yml
+++ b/.github/workflows/update_dockerhub_description.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0


### PR DESCRIPTION
## Problem

The vulnerability scan opened **duplicate** auto-fix PRs (#129 and #130 are byte-identical: bump lego 5.2.1→5.2.2 + remove the libxml2 pin).

The dedup guard keys off `CVE-XXXX-YYYY` IDs scraped from open security PR bodies. But two fix types — **lego version bumps** and **stale-pin removals** — write no CVE ID into the body, so the guard finds nothing to match, assumes nothing is covered, and opens a fresh identical PR every scan. The date-based branch name (`fix/cve-<date>`) doesn't stop it either.

## Fix

Before committing, compare the proposed `src/Dockerfile*` contents against every open `security`-labelled PR. If one already proposes the exact same files, skip instead of creating a duplicate. This is content-based, so it catches all fix types regardless of whether a CVE ID is present.

## Test plan

- [x] `scan_vulnerabilities.yml` parses as valid YAML
- [ ] Validated on the next scheduled scan (should now skip when an identical open PR exists)

## Cleanup

#129 and #130 are duplicates — close one (and they overlap with the dedicated lego bump #125). Closing is a web-UI action on your side.