### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-06-22)

### DIFF
--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -69,6 +69,10 @@ RUN chmod +x -R /scripts && \
 
 
 
+# --- CVE security pins (auto-managed) ---
+RUN apk add --no-cache libexpat=2.8.1-r0 libxml2=2.13.9-r1
+# --- end CVE security pins ---
+
 VOLUME /etc/letsencrypt
 
 # The Nginx parent Docker image already expose port 80, so we only need to add


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-06-22).

**lego transitive CVEs (gobinary):** lego already at latest (5.2.2); transitive CVEs require an upstream lego release

**OS package CVEs pinned:**
- `CVE-2026-45186` — libexpat (alpine) → `2.8.1-r0`
- `CVE-2026-6732` — libxml2 (alpine) → `2.13.9-r1`