### PR TITLE
Bump nginx from 1.31.1 to 1.31.2

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.31.1@sha256:5aca99593157f4ae539a5dec1092a0ad8762f8e2eb1789085a13a0f5622369f6
+FROM nginx:1.31.2@sha256:42f2d24ae18df9b5251d1cc45548085656d2335e9338fd150a24e415462d151f
 LABEL maintainer="emulatorchen"
 
 # FORK: Python/certbot/Rust removed. Only the static lego binary is installed.

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM nginx:1.31.1-alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a
+FROM nginx:1.31.2-alpine@sha256:20316569d8f81a160065d7d2a5eeffc7ca97d79022462ee255fd23fa103a6b5c
 LABEL maintainer="emulatorchen"
 
 # FORK: Python/certbot removed. Only the static lego binary is installed.

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 # When merging lego version bumps: update ARG LEGO_VERSION below.
 # Skip all certbot/Python changes from upstream — they are intentionally removed.
 
-ARG NGINX_VERSION=1.31.1
+ARG NGINX_VERSION=1.31.2
 ARG LEGO_VERSION=5.2.2
 ARG TARGETARCH
 ARG TARGETVARIANT


### PR DESCRIPTION
Automated nginx version bump.

- **From:** `1.31.1`
- **To:** `1.31.2`
- **Release notes:** https://nginx.org/en/CHANGES

This PR was opened automatically by the `check-nginx-update` workflow.
The build CI will validate the new image across all platforms.