### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-06-29)

### DIFF
--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -69,9 +69,6 @@ RUN chmod +x -R /scripts && \
 
 
 
-# --- CVE security pins (auto-managed) ---
-RUN apk add --no-cache libexpat=2.8.1-r0
-# --- end CVE security pins ---
 
 VOLUME /etc/letsencrypt
 


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-06-29).

**lego transitive CVEs (gobinary):** lego already at latest (5.2.2); transitive CVEs require an upstream lego release

**Stale OS package pins removed:** base image update resolved the CVE natively — hardcoded version pins are no longer needed.