### PR TITLE
test: use example.com placeholders in lego migration fixtures and docs

### DIFF
--- a/src/scripts/run_lego.sh
+++ b/src/scripts/run_lego.sh
@@ -84,8 +84,8 @@ determine_authenticator() {
 # Handles both new-style and legacy patterns:
 #   example.com.dns-cloudflare       → provider=cloudflare  suffix=
 #   example.com.dns-cloudflare_1     → provider=cloudflare  suffix=_1
-#   lalatina-freemyip.dns-multi      → provider=multi       suffix=
-#   lalatina-freemyip.dns-multi_2    → provider=multi       suffix=_2
+#   example.com.dns-multi            → provider=multi       suffix=
+#   example.com.dns-multi_2          → provider=multi       suffix=_2
 get_cert_provider_and_suffix() {
     local cert_name="${1}"
     provider=""

--- a/tests/fixtures/lego_migration/nginx_conf/dns_multi.conf
+++ b/tests/fixtures/lego_migration/nginx_conf/dns_multi.conf
@@ -1,7 +1,7 @@
 server {
     listen 443 ssl;
-    server_name lalatina.freemyip.com *.lalatina.freemyip.com;
-    ssl_certificate     /etc/letsencrypt/live/lalatina-freemyip.dns-multi/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/lalatina-freemyip.dns-multi/privkey.pem;
+    server_name example.com *.example.com;
+    ssl_certificate     /etc/letsencrypt/live/example.com.dns-multi/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com.dns-multi/privkey.pem;
     location / { return 200 "ok"; }
 }

--- a/tests/validate_lego_migration.bats
+++ b/tests/validate_lego_migration.bats
@@ -64,12 +64,12 @@ setup() {
 }
 
 @test "determine_authenticator: cert name with .dns-multi → dns-multi" {
-    result=$(determine_authenticator "lalatina-freemyip.dns-multi")
+    result=$(determine_authenticator "example.com.dns-multi")
     [ "${result}" = "dns-multi" ]
 }
 
 @test "determine_authenticator: cert name with .dns-multi_2 → dns-multi (suffix stripped for auth)" {
-    result=$(determine_authenticator "lalatina-freemyip.dns-multi_2")
+    result=$(determine_authenticator "example.com.dns-multi_2")
     [ "${result}" = "dns-multi" ]
 }
 
@@ -214,14 +214,14 @@ setup() {
 
 @test "get_cert_provider_and_suffix: dns-multi → provider=multi suffix=''" {
     provider="" suffix=""
-    get_cert_provider_and_suffix "lalatina-freemyip.dns-multi"
+    get_cert_provider_and_suffix "example.com.dns-multi"
     [ "${provider}" = "multi" ]
     [ "${suffix}" = "" ]
 }
 
 @test "get_cert_provider_and_suffix: dns-multi_2 → provider=multi suffix=_2" {
     provider="" suffix=""
-    get_cert_provider_and_suffix "lalatina-freemyip.dns-multi_2"
+    get_cert_provider_and_suffix "example.com.dns-multi_2"
     [ "${provider}" = "multi" ]
     [ "${suffix}" = "_2" ]
 }


### PR DESCRIPTION
Replace real deployment domain names in test fixtures, bats assertions, and inline docs with example.com placeholders. No secrets were involved — the credential fixtures already used fake test tokens; only domain names were real.

Behavior-preserving: the cert-name parser keys off the .dns-<provider> token and _N suffix, not the name prefix, so determine_authenticator and get_cert_provider_and_suffix assertions are unchanged. Matches the existing example.com.dns-route53 test style.