### PR TITLE
fix: lego 5.x renewal — use 'run' (lego dropped 'renew'), add --renew-days/--ari-disable, honor cert-name suffix, provider fallback

### DIFF
--- a/src/scripts/run_lego.sh
+++ b/src/scripts/run_lego.sh
@@ -174,13 +174,16 @@ get_certificate_lego() {
     local lego_certs_dir="${LEGO_PATH}/certificates"
     local lego_cert="${lego_certs_dir}/${lego_cert_name}.crt"
 
-    # Use 'run' for a new certificate, 'renew' for an existing one.
+    # lego 5.x has no 'renew' command — 'run' obtains a new certificate or
+    # renews an existing one. --renew-days sets the renewal window (lego skips
+    # the renewal if the cert is not yet within that many days of expiry).
+    # --ari-disable avoids ACME Renewal Info 'replaces' failures when a cert was
+    # originally issued by a different ACME account (e.g. a certbot->lego
+    # migration), where this account "did not request the certificate being
+    # replaced". (${lego_cert} existence is no longer used to pick the subcommand.)
     local lego_subcmd="run"
-    local lego_extra_args=()
-    if [ -f "${lego_cert}" ]; then
-        lego_subcmd="renew"
-        [ -n "${force_renew}" ] && lego_extra_args+=("${force_renew}")
-    fi
+    local lego_extra_args=("--renew-days" "${RENEW_DAYS:-30}" "--ari-disable")
+    [ -n "${force_renew}" ] && lego_extra_args+=("--renew-force")
 
     if [ "${authenticator}" = "webroot" ]; then
         # HTTP-01 challenge via lego webroot.
@@ -198,15 +201,22 @@ get_certificate_lego() {
             "${lego_extra_args[@]}" || return 1
     else
         # DNS-01 challenge.
-        local provider="" creds_suffix=""
+        local provider="" suffix=""
         get_cert_provider_and_suffix "${cert_name}"
         local dns_provider="${provider}"
+
+        # Cert names without a 'dns-<provider>' token (e.g. 'example-duckdns')
+        # leave the provider empty; fall back to the authenticator resolved
+        # above (from LEGO_DEFAULT_PROVIDER / CERTBOT_AUTHENTICATOR).
+        if [ -z "${dns_provider}" ]; then
+            dns_provider="${authenticator#dns-}"
+        fi
 
         # For legacy dns-multi, the actual lego provider is inside the .ini file.
         local -a env_args=()
         if [ -n "${dns_provider}" ]; then
             local creds_output
-            creds_output=$(load_credentials "${dns_provider}" "${creds_suffix}") || return 1
+            creds_output=$(load_credentials "${dns_provider}" "${suffix}") || return 1
 
             # Override provider if the .ini file specifies dns_multi_provider.
             while IFS= read -r creds_line; do

--- a/tests/validate_lego_migration.bats
+++ b/tests/validate_lego_migration.bats
@@ -225,3 +225,66 @@ setup() {
     [ "${provider}" = "multi" ]
     [ "${suffix}" = "_2" ]
 }
+
+# ===========================================================================
+# get_certificate_lego() — lego 5.x command construction
+# A mock 'lego' on PATH captures argv + injected env, so these run in CI with
+# no network and no real issuance. Covers the lego-5.x correctness fixes:
+#   - 'run' subcommand (lego 5.x has no 'renew'); flags are run options (after it)
+#   - --renew-days (renewal window) + --ari-disable (cross-account ARI replace)
+#   - cert-name suffix reaches load_credentials (was dropped into 'creds_suffix')
+#   - names without a dns-<provider> token fall back to the authenticator
+# ===========================================================================
+
+_install_lego_mock() {
+    MOCK_BIN="$(mktemp -d)"
+    LEGO_ARGS_FILE="$(mktemp)"
+    cat > "${MOCK_BIN}/lego" <<LEGO_MOCK_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "${LEGO_ARGS_FILE}"
+env | grep -E '_TOKEN=|_DNS_API_TOKEN=|DO_AUTH_TOKEN=' >> "${LEGO_ARGS_FILE}" || true
+exit 0
+LEGO_MOCK_EOF
+    chmod +x "${MOCK_BIN}/lego"
+    PATH="${MOCK_BIN}:${PATH}"
+}
+
+@test "get_certificate_lego: invokes 'run' (not 'renew') with flags after the subcommand" {
+    _install_lego_mock
+    run get_certificate_lego "example.com.dns-cloudflare" "example.com" "ecdsa"
+    [ "${status}" -eq 0 ]
+    # lego 5.x: subcommand first, its options after it.
+    [ "$(head -n1 "${LEGO_ARGS_FILE}")" = "run" ]
+    ! grep -qx "renew" "${LEGO_ARGS_FILE}"
+    grep -qx -- "--path" "${LEGO_ARGS_FILE}"
+    local run_line path_line
+    run_line=$(grep -nx "run" "${LEGO_ARGS_FILE}" | head -n1 | cut -d: -f1)
+    path_line=$(grep -nx -- "--path" "${LEGO_ARGS_FILE}" | head -n1 | cut -d: -f1)
+    [ "${path_line}" -gt "${run_line}" ]
+}
+
+@test "get_certificate_lego: includes --renew-days and --ari-disable" {
+    _install_lego_mock
+    run get_certificate_lego "example.com.dns-cloudflare" "example.com" "ecdsa"
+    [ "${status}" -eq 0 ]
+    grep -qx -- "--renew-days" "${LEGO_ARGS_FILE}"
+    grep -qx -- "--ari-disable" "${LEGO_ARGS_FILE}"
+}
+
+@test "get_certificate_lego: suffixed cert name loads the matching creds file (suffix not dropped)" {
+    _install_lego_mock
+    run get_certificate_lego "example.com.dns-cloudflare_1" "example.com" "ecdsa"
+    [ "${status}" -eq 0 ]
+    grep -q "CLOUDFLARE_DNS_API_TOKEN=test-token-cf-1" "${LEGO_ARGS_FILE}"
+}
+
+@test "get_certificate_lego: cert name without dns- token falls back to CERTBOT_AUTHENTICATOR provider" {
+    export CERTBOT_AUTHENTICATOR="dns-cloudflare"
+    _install_lego_mock
+    run get_certificate_lego "example-duckdns" "service.example.com" "ecdsa"
+    [ "${status}" -eq 0 ]
+    local dns_line
+    dns_line=$(grep -nx -- "--dns" "${LEGO_ARGS_FILE}" | head -n1 | cut -d: -f1)
+    [ -n "${dns_line}" ]
+    [ "$(sed -n "$((dns_line + 1))p" "${LEGO_ARGS_FILE}")" = "cloudflare" ]
+}


### PR DESCRIPTION
Auto-renewal has been failing since the lego 5.x upgrade.

Root causes, all in `get_certificate_lego` (`src/scripts/run_lego.sh`):

1. lego 5.x has no `renew` subcommand — `lego renew …` makes lego parse the flags as global options and reject `--path` ("flag provided but not defined: -path"). Renewal is now `lego run --renew-days N` (`run` obtains-or-renews), with flags after the subcommand.
2. The cert-name suffix was read into `creds_suffix`, but the helper sets `suffix` — so suffixed cert names silently loaded the base credentials file (wrong tokens).
3. Cert names without a `dns-<provider>` token left `--dns` empty ("unrecognized DNS provider"); now falls back to the authenticator resolved from `LEGO_DEFAULT_PROVIDER` / `CERTBOT_AUTHENTICATOR`.

Also adds `--ari-disable` — ACME Renewal Info "replaces" returns 403 when the cert was originally issued by a different ACME account (e.g. a certbot->lego migration).
