### PR TITLE
fix(ci): apt retries + timeouts for ubuntu-arm64 build (ports.ubuntu.com flakiness)

### DIFF
--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -16,6 +16,8 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 RUN set -ex && \
+    printf 'Acquire::Retries "8";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::https::Verify-Peer "false";\nAcquire::https::Verify-Host "false";\n' > /etc/apt/apt.conf.d/99net-resilience && \
+    find /etc/apt -type f \( -name '*.sources' -o -name '*.list' \) -exec sed -i 's|http://ports.ubuntu.com|https://ports.ubuntu.com|g' {} + && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \


### PR DESCRIPTION
The Ubuntu **arm64** image build intermittently fails at `apt-get`:

```
E: Failed to fetch http://ports.ubuntu.com/.../*_arm64.deb  Unable to connect to ports.ubuntu.com:80
```

Under QEMU emulation the arm64 leg frequently times out reaching `ports.ubuntu.com`. This adds an `apt.conf.d` drop-in (`Acquire::Retries=8`, 30s http/https timeouts) so apt retries the flaky fetches instead of failing the build. The amd64, alpine and debian legs are unaffected.
