### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-07-20)

### DIFF
--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -70,6 +70,10 @@ RUN chmod +x -R /scripts && \
 
 
 
+# --- CVE security pins (auto-managed) ---
+RUN apk add --no-cache c-ares=1.34.8-r0 curl=8.20.0-r0 libcurl=8.20.0-r0 libexpat=2.8.2-r0
+# --- end CVE security pins ---
+
 VOLUME /etc/letsencrypt
 
 # The Nginx parent Docker image already expose port 80, so we only need to add


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-07-20).

**lego transitive CVEs (gobinary):** lego already at latest (5.2.2); transitive CVEs require an upstream lego release

**OS package CVEs pinned:**
- `CVE-2026-33630` — c-ares (alpine) → `1.34.8-r0`
- `CVE-2026-45186` — libexpat (alpine) → `2.8.1-r0`
- `CVE-2026-56131` — libexpat (alpine) → `2.8.2-r0`
- `CVE-2026-56407` — libexpat (alpine) → `2.8.2-r0`
- `CVE-2026-56408` — libexpat (alpine) → `2.8.2-r0`
- `CVE-2026-5773` — curl (alpine) → `8.20.0-r0`
- `CVE-2026-5773` — libcurl (alpine) → `8.20.0-r0`
- `CVE-2026-6276` — curl (alpine) → `8.20.0-r0`
- `CVE-2026-6276` — libcurl (alpine) → `8.20.0-r0`