### PR TITLE
fix: auto-fix CVEs from vulnerability scan (2026-07-27)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python/Rust changes — they are intentionally removed.
 
-ARG LEGO_VERSION=5.2.2
+ARG LEGO_VERSION=5.3.1
 ARG TARGETARCH
 ARG TARGETVARIANT
 
@@ -69,6 +69,12 @@ RUN chmod +x -R /scripts && \
 
 
 
+
+# --- CVE security pins (auto-managed) ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libtiff6=4.7.0-3+deb13u3 \
+    && rm -rf /var/lib/apt/lists/*
+# --- end CVE security pins ---
 
 VOLUME /etc/letsencrypt
 

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -10,7 +10,7 @@ LABEL maintainer="emulatorchen"
 #   - Review COPY scripts/ and lines after it for nginx-layer changes.
 #   - Skip all certbot/Python changes — they are intentionally removed.
 
-ARG LEGO_VERSION=5.2.2
+ARG LEGO_VERSION=5.3.1
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/src/Dockerfile-ubuntu
+++ b/src/Dockerfile-ubuntu
@@ -11,7 +11,7 @@ LABEL maintainer="emulatorchen"
 # Skip all certbot/Python changes from upstream — they are intentionally removed.
 
 ARG NGINX_VERSION=1.31.3
-ARG LEGO_VERSION=5.2.2
+ARG LEGO_VERSION=5.3.1
 ARG TARGETARCH
 ARG TARGETVARIANT
 


### PR DESCRIPTION
Auto-fix PR for CVEs detected in weekly vulnerability scan (2026-07-27).

**lego transitive CVEs (gobinary):** Bumped lego 5.2.2 → 5.3.1

**OS package CVEs pinned:**
- `CVE-2026-12912` — libtiff6 (debian) → `4.7.0-3+deb13u3`